### PR TITLE
README: list Fedora packages to install

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,16 +28,18 @@ Building
 On Arch Linux, use the [AUR
 package](https://aur.archlinux.org/packages.php?ID=35326).
 
-On Ubuntu:
-
-* First, install these packages:
+* On Ubuntu, install these packages:
 
       sudo apt-get install build-essential libmotif-dev libjpeg62-dev libpng12-dev x11proto-print-dev libxmu-headers libxpm-dev libxmu-dev
+      
+* On Fedora, install these packages:
 
-* Next, build with:
+      sudo dnf install @development-tools motif-devel libjpeg-turbo libpng12-devel xorg-x11-proto-devel libXmu-devel libXpm-devel
+
+Next, build with:
 
       make linux
 
-* Run!
+Run!
 
       src/Mosaic


### PR DESCRIPTION
Tested on Fedora 30, x86_64.

Original repo, as of https://github.com/alandipert/ncsa-mosaic/tree/1997c69ca634813d7f7d91ea5b5540fcc1ef8b79, doesn't build for me on Fedora.  
This fork does :tada: :bowing_man: 

<details>

Not sure why, Fedora does have a `libpng12-devel` library, so shouldn't require the changes here for  libpng 1.5 support?  Anyway they helped :grinning:.  
Here is the error from orignal fork:

```
readPNG.c: In function ‘ReadPNG’:
readPNG.c:179:26: error: dereferencing pointer to incomplete type ‘png_struct’ {aka ‘struct png_struct_def’}
  179 |     *width = (int)png_ptr->width;
      |                          ^~
readPNG.c:186:52: error: dereferencing pointer to incomplete type ‘png_info’ {aka ‘struct png_info_def’}
  186 |         fprintf(stderr,"bit depth = %d\n", info_ptr->bit_depth);
      |                                                    ^~
readPNG.c:242:13: warning: implicit declaration of function ‘png_set_dither’; did you mean ‘png_set_filter’? [-Wimplicit-function-declaration]
  242 |             png_set_dither(png_ptr, std_color_cube,
      |             ^~~~~~~~~~~~~~
      |             png_set_filter
readPNG.c:102:18: warning: unused variable ‘packets’ [-Wunused-variable]
  102 |     unsigned int packets;
      |                  ^~~~~~~
make[2]: *** [<builtin>: readPNG.o] Error 1
```

</details>
